### PR TITLE
Refactor/model wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,71 @@
-## [0.1.0] - 2025-04-18
+## [0.2.0] - 2025-04-20 [🔗](https://github.com/W-Thurston/automl_assumption_checker/releases/tag/v0.2.0)
+
 ### Added
-- Dockerfile and CI setup
-- Smoke test for CLI
-- CONTRIBUTING.md and issue templates
+
+- Introduced `ModelWrapper` abstraction layer:
+  - Base interface `BaseModelWrapper`
+  - `LinearModelWrapper` implementation for `statsmodels.OLS`
+  - Shared `get_model_wrapper()` factory in `models/utils.py`
+- Shared model now fit once and reused across all assumption checks
+- `--model-type` CLI flag in `report.py` (currently supports `"linear"`)
+- Console report now prints model metadata using `model_wrapper.summary()`
+- Assumption check registry (`register_assumption`) extended to support model filtering via `model_types`
+- Centralized `run_all_checks()` returns both results and model instance
+- Updated `linearity.py` to use shared model wrapper for residuals and fitted values
+- Auto-skips linearity check with multivariate input but shows informative output panel
 
 ### Changed
-- Upgraded Python to 3.12.10
+
+- Function parameter order across assumption checks standardized:
+  - Optional arguments like `model_wrapper` now follow `return_plot` for readability
+- Assumption checks now accept `model_wrapper` as a shared input
+- Dispatcher updated to enforce model compatibility filtering by `model_type`
 
 ### Fixed
+
+- CLI crash when `model_type` was not explicitly passed
+- Alignment inconsistencies in verbose mode console report
+
+### Upcoming
+
+- Refactor `normality`, `homoscedasticity`, and `multicollinearity` to use `model_wrapper`
+- Add new assumptions: `influence`, `outliers`, `independence`, `missingness`
+- Enable diagnostics for multivariate inputs
+- Full v1.0.0 milestone to mark linear regression support completion
+
+## [0.1.0] - 2025-04-19 [🔗](https://github.com/W-Thurston/automl_assumption_checker/releases/tag/v0.1.0)
+
+### Added
+
+- Three core assumption modules:
+  - Linearity (`R²` with threshold and visual)
+  - Homoscedasticity (Breusch-Pagan test)
+  - Normality (Shapiro, D’Agostino, Anderson)
+- `report.py` with:
+  - Rich console summary (color-coded, threshold-aware)
+  - Markdown and JSON export support
+  - Verbose mode with diagnostic detail alignment
+- Unified `AssumptionResult` dataclass for structured output
+- Registry-based dispatcher system
+- Plot support using base64-encoded figures
+- Simulated data generators for testing + diagnostics
+
+### Changed
+
+- Upgraded Python to 3.12.10
+- Normality test now uses majority rule logic for combined verdicts
+
+### Fixed
+
 - Docker DNS resolution on WSL2
+- CLI pre-commit conflict between `black` and `isort`
+
+### Upcoming
+
+- Planned `multicollinearity.py` assumption checker
+- Planned `independence.py` assumption checker
+- Planned `influence.py` assumption checker
+- Planned `outliers.py` assumption checker
+- Planned `missingness.py` assumption checker
+- Streamlit-based visual report interface
+- CLI wrapper with CSV input support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [0.2.1] - 2025-04-22 [🔗](https://github.com/W-Thurston/automl_assumption_checker/releases/tag/v0.2.1)
+
+### Refactored
+- Implemented ModelWrapper architecture in the following linear model assumptions:
+  - homoscedasticity
+  - normality
+  - multicollinearity
+
 ## [0.2.0] - 2025-04-20 [🔗](https://github.com/W-Thurston/automl_assumption_checker/releases/tag/v0.2.0)
 
 ### Added

--- a/app/core/multicollinearity.py
+++ b/app/core/multicollinearity.py
@@ -20,9 +20,9 @@ from app.utils import build_result, classify_severity, fig_to_base64
 __all__ = ["check_multicollinearity"]
 
 
-@register_assumption("multicollinearity")
+@register_assumption("multicollinearity", model_types=["linear"])
 def check_multicollinearity(
-    X: pd.DataFrame, y: pd.Series, return_plot: bool = False
+    X: pd.DataFrame, y: pd.Series, return_plot: bool = False, model_wrapper=None
 ) -> AssumptionResult:
     """
     Check multicollinearity assumption using:

--- a/app/core/registry.py
+++ b/app/core/registry.py
@@ -14,7 +14,9 @@ ASSUMPTION_CHECKS: Dict[
 AssumptionCheck = Callable[[pd.Series, pd.Series, bool], AssumptionResult]
 
 
-def register_assumption(name: str) -> Callable[[AssumptionCheck], AssumptionCheck]:
+def register_assumption(
+    name: str, model_types: list = ["linear"]
+) -> Callable[[AssumptionCheck], AssumptionCheck]:
     """
     Decorator to register an assumption check function under a given name.
 
@@ -26,6 +28,8 @@ def register_assumption(name: str) -> Callable[[AssumptionCheck], AssumptionChec
     """
 
     def decorator(func: AssumptionCheck) -> AssumptionCheck:
+        func._assumption_name = name
+        func._model_types = model_types
         ASSUMPTION_CHECKS[name] = func
         return func
 

--- a/app/models/base_model_wrapper.py
+++ b/app/models/base_model_wrapper.py
@@ -1,0 +1,22 @@
+from abc import ABC, abstractmethod
+
+
+class BaseModelWrapper(ABC):
+    def __init__(self, X, y):
+        self.X = X
+        self.y = y
+
+    @abstractmethod
+    def fit(self): ...
+
+    @abstractmethod
+    def predict(self): ...
+
+    @abstractmethod
+    def residuals(self): ...
+
+    @abstractmethod
+    def fitted(self): ...
+
+    def summary(self):
+        return {}

--- a/app/models/linear_model_wrapper.py
+++ b/app/models/linear_model_wrapper.py
@@ -1,0 +1,21 @@
+import statsmodels.api as sm
+
+from app.models.base_model_wrapper import BaseModelWrapper
+
+
+class LinearModelWrapper(BaseModelWrapper):
+    def fit(self):
+        self.model = sm.OLS(self.y, sm.add_constant(self.X)).fit()
+        return self
+
+    def predict(self):
+        return self.model.predict(sm.add_constant(self.X))
+
+    def residuals(self):
+        return self.model.resid
+
+    def fitted(self):
+        return self.model.fittedvalues
+
+    def summary(self):
+        return {"model_type": "Linear Regression", "r_squared": self.model.rsquared}

--- a/app/models/utils.py
+++ b/app/models/utils.py
@@ -1,0 +1,11 @@
+from app.models.base_model_wrapper import BaseModelWrapper
+from app.models.linear_model_wrapper import LinearModelWrapper
+
+
+def get_model_wrapper(model_type: str, X, y) -> BaseModelWrapper:
+    if model_type == "linear":
+        return LinearModelWrapper(X, y).fit()
+    elif model_type == "PLACEHOLDER":
+        ...
+    else:
+        raise ValueError(f"Unsupported model type: {model_type}")

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -20,7 +20,7 @@ def test_dispatch_all_assumptions():
     Test dispatcher's run_all_checks().
     """
     df = simulated_data.generate_linear_data(n_samples=300, seed=42)
-    results = dispatcher.run_all_checks(df["x"], df["y"])
+    results, _ = dispatcher.run_all_checks(df["x"], df["y"], model_type="linear")
     assert "linearity" in results
     assert "homoscedasticity" in results
     assert results["linearity"].passed

--- a/tests/test_homoscedasticity.py
+++ b/tests/test_homoscedasticity.py
@@ -1,6 +1,7 @@
 # tests/test_homoscedasticity.py
 from app.core import homoscedasticity
 from app.data import simulated_data
+from app.models.linear_model_wrapper import LinearModelWrapper
 
 
 def test_homoscedasticity_check_passes_on_linear_data():
@@ -21,3 +22,16 @@ def test_homoscedasticity_plot_generation():
     result = homoscedasticity.check_homoscedasticity(df["x"], df["y"], return_plot=True)
     assert result.plot_base64 is not None
     assert result.plot_base64.startswith("iVBOR")
+
+
+def test_homoscedasticity_with_model_wrapper():
+    """
+    Ensure check_homoscedasticity works when a pre-fit model_wrapper is provided.
+    """
+    df = simulated_data.generate_linear_data(seed=123)
+    wrapper = LinearModelWrapper(df["x"], df["y"]).fit()
+
+    result = homoscedasticity.check_homoscedasticity(
+        df["x"], df["y"], model_wrapper=wrapper
+    )
+    assert "breusch_pagan_pval" in result.details

--- a/tests/test_linear_model_wrapper.py
+++ b/tests/test_linear_model_wrapper.py
@@ -1,0 +1,50 @@
+import numpy as np
+import pandas as pd
+
+from app.models.linear_model_wrapper import LinearModelWrapper
+
+
+def test_linear_wrapper_fit_and_predict():
+    """
+    Test that LinearModelWrapper can fit a model and return predictions.
+    Ensures the fitted model exposes .predict() and matches expected length.
+    """
+    X = pd.DataFrame({"x1": np.random.randn(100)})
+    y = 3 * X["x1"] + np.random.randn(100)
+
+    model = LinearModelWrapper(X, y).fit()
+    preds = model.predict()
+
+    assert len(preds) == len(y)
+    assert hasattr(model, "model")
+
+
+def test_linear_wrapper_residuals_and_fitted():
+    """
+    Verify that residuals + fitted values approximately equal the true target.
+    Confirms internal math and data shape integrity.
+    """
+    X = pd.DataFrame({"x1": np.random.randn(100)})
+    y = 2 * X["x1"] + np.random.randn(100)
+
+    model = LinearModelWrapper(X, y).fit()
+    residuals = model.residuals()
+    fitted = model.fitted()
+
+    # residuals = y - y_pred
+    np.testing.assert_allclose(y.values, residuals + fitted, rtol=1e-4)
+
+
+def test_linear_wrapper_summary():
+    """
+    Confirm the summary() method returns expected keys and types.
+    """
+    X = pd.DataFrame({"x1": np.random.randn(50)})
+    y = X["x1"] + np.random.randn(50)
+
+    model = LinearModelWrapper(X, y).fit()
+    summary = model.summary()
+
+    assert "model_type" in summary
+    assert summary["model_type"].lower() == "linear regression"
+    assert 0 <= summary["r_squared"] <= 1

--- a/tests/test_linearity.py
+++ b/tests/test_linearity.py
@@ -1,6 +1,11 @@
 # tests/test_linearity.py
+import numpy as np
+import pandas as pd
+
 from app.core import linearity
+from app.core.linearity import check_linearity
 from app.data import simulated_data
+from app.models.linear_model_wrapper import LinearModelWrapper
 
 
 def test_linearity_r_squared_threshold():
@@ -21,3 +26,15 @@ def test_linearity_plot_generation():
     result = linearity.check_linearity(df["x"], df["y"], return_plot=True)
     assert result.plot_base64 is not None
     assert result.plot_base64.startswith("iVBOR")  # PNG header in base64
+
+
+def test_linearity_with_model_wrapper():
+    """
+    Ensure check_linearity works when a pre-fit model_wrapper is provided.
+    """
+    X = pd.DataFrame({"x1": np.random.randn(100)})
+    y = 2 * X["x1"] + np.random.randn(100)
+    wrapper = LinearModelWrapper(X, y).fit()
+
+    result = check_linearity(X, y, model_wrapper=wrapper)
+    assert "r_squared" in result.details

--- a/tests/test_linearity.py
+++ b/tests/test_linearity.py
@@ -1,9 +1,5 @@
 # tests/test_linearity.py
-import numpy as np
-import pandas as pd
-
 from app.core import linearity
-from app.core.linearity import check_linearity
 from app.data import simulated_data
 from app.models.linear_model_wrapper import LinearModelWrapper
 
@@ -32,9 +28,8 @@ def test_linearity_with_model_wrapper():
     """
     Ensure check_linearity works when a pre-fit model_wrapper is provided.
     """
-    X = pd.DataFrame({"x1": np.random.randn(100)})
-    y = 2 * X["x1"] + np.random.randn(100)
-    wrapper = LinearModelWrapper(X, y).fit()
+    df = simulated_data.generate_linear_data(seed=123)
+    wrapper = LinearModelWrapper(df["x"], df["y"]).fit()
 
-    result = check_linearity(X, y, model_wrapper=wrapper)
+    result = linearity.check_linearity(df["x"], df["y"], model_wrapper=wrapper)
     assert "r_squared" in result.details

--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -1,0 +1,30 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from app.models.linear_model_wrapper import LinearModelWrapper
+from app.models.utils import get_model_wrapper
+
+
+def test_get_model_wrapper_linear():
+    """
+    Verify get_model_wrapper returns a LinearModelWrapper for 'linear' input.
+    """
+    X = pd.DataFrame({"x1": np.random.randn(30)})
+    y = 2 * X["x1"] + np.random.randn(30)
+
+    wrapper = get_model_wrapper("linear", X, y)
+    assert isinstance(wrapper, LinearModelWrapper)
+    assert hasattr(wrapper, "predict")
+    assert hasattr(wrapper, "residuals")
+
+
+def test_get_model_wrapper_invalid_type():
+    """
+    Confirm get_model_wrapper raises ValueError for unknown model_type.
+    """
+    X = pd.DataFrame({"x1": np.random.randn(30)})
+    y = 2 * X["x1"] + np.random.randn(30)
+
+    with pytest.raises(ValueError, match="Unsupported model type"):
+        get_model_wrapper("invalid_type", X, y)

--- a/tests/test_multicollinearity.py
+++ b/tests/test_multicollinearity.py
@@ -10,7 +10,7 @@ def test_single_feature_skips_check():
     y = 2 * X["x"] + np.random.normal(size=100)
 
     result = check_multicollinearity(X, y)
-    assert result.passed is True
+    assert result.passed
     assert "not applicable" in result.summary.lower()
 
 
@@ -25,7 +25,7 @@ def test_low_vif_passes():
     y = X["x1"] + X["x2"] + rng.normal(size=100)
 
     result = check_multicollinearity(X, y)
-    assert result.passed is True
+    assert result.passed
     for key in result.details:
         if "(VIF)" in key:
             assert result.details[key] < VIF_THRESHOLD

--- a/tests/test_normality.py
+++ b/tests/test_normality.py
@@ -1,5 +1,6 @@
 from app.core import normality
 from app.data import simulated_data
+from app.models.linear_model_wrapper import LinearModelWrapper
 
 
 def test_normality_check_passes_on_normal_data():
@@ -34,3 +35,14 @@ def test_normality_plot_generation():
     assert len(result.plots) >= 2
     assert all("image" in plot for plot in result.plots)
     assert all(plot["image"].startswith("iVBOR") for plot in result.plots)  # PNG base64
+
+
+def test_normality_with_model_wrapper():
+    """
+    Ensure check_normality works when a pre-fit model_wrapper is provided.
+    """
+    df = simulated_data.generate_linear_data(seed=123)
+    wrapper = LinearModelWrapper(df["x"], df["y"]).fit()
+
+    result = normality.check_normality(df["x"], df["y"], model_wrapper=wrapper)
+    assert "shapiro_pval" in result.details


### PR DESCRIPTION
### What does this PR do?

This release introduces the ModelWrapper abstraction system and shared model state across all assumption checks.
✨ Highlights

    Added BaseModelWrapper and LinearModelWrapper
    Only fit one model per dataset, shared across all assumptions
    New CLI flag: --model-type (currently supports "linear")
    Rich console output now includes model metadata
    Refactored linearity.py to use wrapper-based architecture
    Assumption checks can now declare supported model types via @register_assumption(model_types=...)

🛠 Internal Improvements

    Dispatcher now returns both results and model
    Parameter orders standardized across assumption checks
    Improved crash safety and default fallbacks


### Related Issues

None

### Checklist

- [x] Code passes pre-commit hooks
- [x] CI passes
- [x] Tests added or updated
- [x] Documentation updated (if applicable)
