### PR TITLE
Feature/independence

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -3,6 +3,7 @@ LINEARITY_R2_THRESHOLD = 0.7
 HOMOSCEDASTICITY_PVAL_THRESHOLD = 0.05
 NORMALITY_PVAL_THRESHOLD = 0.05
 VIF_THRESHOLD = 5
+INDEPENDENCE_DW_THRESHOLDS = (1.5, 2.5)
 
 # Thresholds for diagnostic severity (optional, used for display or flagging)
 R2_SEVERITY_THRESHOLDS = {"high": 0.9, "moderate": 0.7, "low": 0.5}

--- a/src/core/homoscedasticity.py
+++ b/src/core/homoscedasticity.py
@@ -35,6 +35,8 @@ def check_homoscedasticity(
         X (pd.Series): Predictor (1D)
         y (pd.Series): Response (1D)
         return_plot (bool, optional): Whether to return a plot. Defaults to False.
+        model_wrapper (optional): Shared fitted model object.
+            If None, a linear model will be created.
 
     Returns:
         AssumptionResult: Structured diagnostic output.

--- a/src/core/independence.py
+++ b/src/core/independence.py
@@ -1,0 +1,133 @@
+# src/core/independence.py
+"""
+Check for Independence of Residuals using
+    - Plots:
+        - Residuals vs Time (if time component exists)
+        - Lag plot or autocorrelation function (ACF)
+    - Statistical tests:
+        - Durbin-Watson Test
+"""
+
+import matplotlib.pyplot as plt
+import pandas as pd
+import seaborn as sns
+from statsmodels.graphics.tsaplots import plot_acf
+from statsmodels.stats.stattools import durbin_watson
+
+from src.config import INDEPENDENCE_DW_THRESHOLDS
+from src.core.registry import register_assumption
+from src.core.types import AssumptionResult
+from src.utils import build_result, classify_severity, fig_to_base64
+
+__all__ = ["check_independence"]
+
+
+@register_assumption("independence", model_types=["linear"])
+def check_independence(
+    X: pd.Series, y: pd.Series, return_plot: bool = False, model_wrapper=None
+) -> AssumptionResult:
+    """
+    Check for Independence of Residuals using
+    - Plots:
+        - Residuals vs Time (if time component exists)
+        - Lag plot or autocorrelation function (ACF)
+    - Statistical tests:
+        - Durbin-Watson Test
+
+    This assumption ensures that residuals are not autocorrelated.
+        Which is especially important in time series or ordered data.
+        The Durbin-Watson statistic provides a formal test, and plots
+        can visually highlight correlation patterns.
+
+    Args:
+        X (pd.Series or pd.DataFrame): Predictor(s), 1D or multivariate
+        y (pd.Series): Response variable
+        return_plot (bool, optional): Whether to include diagnostic plots.
+            Defaults to False.
+        model_wrapper (optional): Shared fitted model object.
+            If None, a linear model will be created.
+
+    Returns:
+        AssumptionResult: Structured diagnostic output.
+    """
+
+    # Guard for if model_wrapper is None
+    if model_wrapper is None:
+        from src.models.utils import get_model_wrapper
+
+        model_wrapper = get_model_wrapper("linear", X, y)
+
+    # Fit simple linear model to input data
+    residuals = model_wrapper.residuals()
+    y_pred = model_wrapper.fitted()
+
+    # Durbin-Watson test
+    dw = durbin_watson(resids=residuals)
+
+    DW_LOWER_BOUND = INDEPENDENCE_DW_THRESHOLDS[0]
+    DW_UPPER_BOUND = INDEPENDENCE_DW_THRESHOLDS[1]
+
+    # Determine if test passed or failed based on thresholds
+    passed = DW_LOWER_BOUND <= dw <= DW_UPPER_BOUND
+
+    # Determine severity of violation based on Durbin-Watson value
+    severity = classify_severity(dw, (DW_LOWER_BOUND, DW_UPPER_BOUND))
+
+    # Recommend next steps if residuals are
+    recommendation = (
+        None
+        if passed
+        else (
+            "Check for autocorrelation in residuals. "
+            "Consider using time series models (e.g., ARIMA) or adding lag features."
+        )
+    )
+
+    # Set flag for UI or prioritization
+    flag = "info" if passed else "warning"
+
+    # Plot Residual plot and Autocorrelation plot if requested
+    plots = []
+    if return_plot:
+        # Residual Plot
+        fig1, ax1 = plt.subplots()
+        sns.residplot(x=y_pred, y=residuals, ax=ax1)
+        ax1.set_title("Residuals vs Fitted")
+        ax1.set_xlabel("Fitted Values")
+        ax1.set_ylabel("Residuals")
+        plots.append(
+            {
+                "title": "Residual Plot",
+                "type": "residplot",
+                "image": fig_to_base64(fig1),
+            }
+        )
+
+        # ACF plot
+        fig2, ax2 = plt.subplots()
+        plot_acf(residuals, ax=ax2, lags=20)
+        ax2.set_title("Autocorrelation Function (ACF) of Residuals")
+        plots.append(
+            {
+                "title": "ACF",
+                "type": "acf",
+                "image": fig_to_base64(fig2),
+            }
+        )
+
+    # Package the diagnostic results using the shared builder
+    return build_result(
+        name="independence",
+        passed=passed,
+        summary=f"Durbin-Watson statistic = {dw:.4f} → {'Pass' if passed else 'Fail'}",
+        details={
+            "durbin_watson": dw,
+            "expected_range": f"{DW_LOWER_BOUND}-{DW_UPPER_BOUND}",
+        },
+        residuals=residuals,
+        fitted=y_pred,
+        plots=plots,
+        severity=severity,
+        recommendation=recommendation,
+        flag=flag,
+    )

--- a/src/core/linearity.py
+++ b/src/core/linearity.py
@@ -35,6 +35,8 @@ def check_linearity(
         y (pd.Series): Response (1D)
         return_plot (bool, optional): Whether to return base64-encoded
             PNG of the plot. Defaults to False.
+        model_wrapper (optional): Shared fitted model object.
+            If None, a linear model will be created.
 
     Returns:
         AssumptionResult: Structured diagnostic output.

--- a/src/core/multicollinearity.py
+++ b/src/core/multicollinearity.py
@@ -33,7 +33,10 @@ def check_multicollinearity(
 
     Args:
         X (pd.DataFrame): Predictor or Feature values (n, p≥2)
+        y (pd.Series): Un-used.
         return_plot (bool, optional): Whether to return a plot. Defaults to False.
+        model_wrapper (optional): Shared fitted model object.
+            If None, a linear model will be created.
 
     Returns:
         AssumptionResult: Structured diagnostic output.

--- a/src/core/normality.py
+++ b/src/core/normality.py
@@ -41,6 +41,8 @@ def check_normality(
         X (pd.Series): Predictor (1D)
         y (pd.Series): Response (1D)
         return_plot (bool, optional): Whether to return a plot. Defaults to False.
+        model_wrapper (optional): Shared fitted model object.
+            If None, a linear model will be created.
 
     Returns:
         AssumptionResult: Structured diagnostic output.

--- a/src/data/simulated_data.py
+++ b/src/data/simulated_data.py
@@ -117,6 +117,29 @@ def generate_skewed_data(n_samples: int = 100, seed: int = None) -> pd.DataFrame
     return pd.DataFrame({"x": x, "y": y})
 
 
+def generate_autocorrelated_data(
+    n_samples: int = 100, seed: int = None
+) -> pd.DataFrame:
+    """
+    Generate linear data with autocorrelated residual structure.
+
+    Simulates a simple trend with a sinusoidal component added to induce
+    autocorrelation in the residuals — commonly used to test independence
+    violations (e.g., time series drift).
+
+    Args:
+        n_samples (int, optional): Number of observations to generate. Defaults to 100.
+        seed (int, optional): Random seed for reproducibility. Defaults to None.
+
+    Returns:
+        pd.DataFrame: A DataFrame with columns 'x' (sequential) and 'y' (autocorrelated)
+    """
+    np.random.seed(seed)
+    x = np.arange(n_samples)
+    y = x + np.sin(np.linspace(0, 10 * np.pi, n_samples))
+    return pd.DataFrame({"x": x, "y": y})
+
+
 def list_simulations() -> dict:
     """
     Return a dictionary of available simulated data generators.
@@ -131,4 +154,5 @@ def list_simulations() -> dict:
         "multicollinear": generate_multicollinear_data,
         "nonlinear": generate_nonlinear_data,
         "skewed": generate_skewed_data,
+        "autocorrelated": generate_autocorrelated_data,
     }

--- a/src/report.py
+++ b/src/report.py
@@ -85,6 +85,8 @@ def print_console_report(results, model_wrapper, verbose: bool = False):
             "dagostino_pval": "≥",
             "anderson_stat": "≤",
             "vif": "≤",
+            "durbin_watson": "in",
+            # Add others as needed
         }
         # Mapping between metrics and their threshold keys
         metric_threshold_pairs = {
@@ -92,6 +94,7 @@ def print_console_report(results, model_wrapper, verbose: bool = False):
             "breusch_pagan_pval": "homoscedasticity_pval_threshold",
             "shapiro_pval": "normality_pval_threshold",
             "dagostino_pval": "normality_pval_threshold",
+            "durbin_watson": "expected_range",
             # Add others as needed
         }
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -72,17 +72,28 @@ def build_result(
     )
 
 
-def classify_severity(value: float, thresholds: dict) -> str:
+def classify_severity(value: float, thresholds: dict | tuple) -> str:
     """
     Classify a numeric value into 'high', 'moderate', or 'low' based on thresholds.
 
+    If a tuple is passed, it's assumed to be a (lower_bound, upper_bound) check.
+    Values inside the range are 'low' severity. Outside = 'high'.
+
     Args:
         value (float): The numeric metric (e.g., R², p-value, VIF).
-        thresholds (dict): Dict with keys 'high', 'moderate', 'low'.
+        thresholds (dict or tuple): Dict with 'high', 'moderate', 'low', or
+         (low, high) bounds.
 
     Returns:
         str: One of 'high', 'moderate', or 'low'
     """
+    if isinstance(thresholds, tuple) and len(thresholds) == 2:
+        low, high = thresholds
+        if low <= value <= high:
+            return "low"
+        else:
+            return "high"
+
     if value >= thresholds["high"]:
         return "high"
     elif value >= thresholds["moderate"]:

--- a/tests/test_independence.py
+++ b/tests/test_independence.py
@@ -1,0 +1,51 @@
+# tests/test_independence.py
+
+from src.core.independence import check_independence
+from src.data import simulated_data
+from src.models.linear_model_wrapper import LinearModelWrapper
+
+
+def test_independence_passes_for_random_residuals():
+    """
+    Check that independence passes when residuals are i.i.d.
+    """
+    df = simulated_data.generate_linear_data(n_samples=200, seed=42)
+    X = df[["x"]]
+    y = df["y"]
+
+    wrapper = LinearModelWrapper(X, y).fit()
+    result = check_independence(X, y, model_wrapper=wrapper)
+
+    assert result.passed
+    assert "durbin_watson" in result.details
+
+
+def test_independence_fails_for_autocorrelated_residuals():
+    """
+    Check that independence fails when residuals are autocorrelated.
+    """
+    df = simulated_data.generate_autocorrelated_data(n_samples=200, seed=42)
+    X = df[["x"]]
+    y = df["y"]
+
+    wrapper = LinearModelWrapper(X, y).fit()
+    result = check_independence(X, y, model_wrapper=wrapper)
+
+    assert not result.passed
+    assert "durbin_watson" in result.details
+    assert (
+        result.details["durbin_watson"] < 1.5 or result.details["durbin_watson"] > 2.5
+    )
+
+
+def test_independence_plot_generation():
+    """
+    Ensure check_independence returns plots if return_plot=True.
+    """
+    df = simulated_data.generate_linear_data(n_samples=200, seed=42)
+    X = df[["x"]]
+    y = df["y"]
+
+    result = check_independence(X, y, return_plot=True)
+    assert isinstance(result.plots, list)
+    assert any("acf" in plot["title"].lower() for plot in result.plots)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -8,7 +8,7 @@ def test_main_script_runs_and_prints_expected_output():
     prints the expected message.
     """
     result = subprocess.run(
-        ["python", "app/main.py"],
+        ["python", "src/main.py"],
         capture_output=True,
         text=True,
     )


### PR DESCRIPTION
### What does this PR do?
feat(assumptions): implement independence check using Durbin-Watson

- Added `check_independence()` to validate residual independence using Durbin-Watson statistic
- Generates optional residual vs fitted plot and ACF plot when `return_plot=True`
- Integrated with `AssumptionResult` system and model_wrapper abstraction
- Added thresholds to `config.py`, and updated `classify_severity()` to support bounded checks
- Registered under `model_types=["linear"]` for dispatcher compatibility
- Added `generate_autocorrelated_data()` to simulated_data for test validation
- Created `test_independence.py` with passing unit tests for i.i.d. and autocorrelated scenarios
- Fully conforms to unified output format and rich report structure

### Related Issues

Closes #[issue number]

### Checklist

- [x] Code passes pre-commit hooks
- [x] CI passes
- [x] Tests added or updated
- [x] Documentation updated (if applicable)
